### PR TITLE
fix insert batch

### DIFF
--- a/src/main/java/io/github/yidasanqian/dynamicadddate/AddDateInterceptor.java
+++ b/src/main/java/io/github/yidasanqian/dynamicadddate/AddDateInterceptor.java
@@ -196,11 +196,11 @@ public class AddDateInterceptor implements Interceptor {
         String camelCaseUpdateDateProperty = StringUtil.camelCase(updateDateColumnName);
         while (it.hasNext()) {
             ParameterMapping pm = it.next();
-            if (pm.getProperty().equals(camelCaseCreateDateProperty)) {
+            if (pm.getProperty().equals(camelCaseCreateDateProperty)|| (pm.getProperty().startsWith("__frch_") &&pm.getProperty().endsWith(camelCaseCreateDateProperty))) {
                 log.debug("原始Sql语句已包含自动添加的列: {}", createDateColumnName);
                 it.remove();
             }
-            if (pm.getProperty().equals(camelCaseUpdateDateProperty)) {
+            if (pm.getProperty().equals(camelCaseUpdateDateProperty)|| (pm.getProperty().startsWith("__frch_") &&pm.getProperty().endsWith(camelCaseUpdateDateProperty))) {
                 log.debug("原始Sql语句已包含自动添加的列: {}", updateDateColumnName);
                 it.remove();
             }


### PR DESCRIPTION
解决批量插入时候，删除ParameterMapping失败的问题。
因为如果是批量插入，自动会对ParameterMapping#property加上__frch_前缀，导致删除的时候匹配不上

见org.apache.ibatis.scripting.xmltags.ForEachSqlNode类